### PR TITLE
refactor data fetching into reusable hook

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Mail, Phone, MapPin, Facebook, Twitter, Instagram } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useData } from '../hooks/useData'
 
 interface TeamInfo {
   teamName: string
@@ -20,7 +20,7 @@ interface TeamInfo {
 }
 
 export default function Footer() {
-  const [teamInfo, setTeamInfo] = useState<TeamInfo>({
+  const defaultInfo: TeamInfo = {
     teamName: 'Shelley Legion',
     tagline: 'Honor, Pride, Victory',
     description: 'Youth baseball team for players 18 and under',
@@ -34,23 +34,10 @@ export default function Footer() {
       twitter: 'https://twitter.com/shelleylegion',
       instagram: 'https://instagram.com/shelleylegion'
     }
-  })
+  }
 
-  useEffect(() => {
-    const loadTeamInfo = async () => {
-      try {
-        const response = await fetch('/api/data/team-info.json')
-        if (response.ok) {
-          const teamInfoData = await response.json()
-          setTeamInfo(teamInfoData as TeamInfo)
-        }
-      } catch (error) {
-        // Keep the default data that was already set
-      }
-    }
+  const { data: teamInfo } = useData<TeamInfo>('team-info.json', defaultInfo)
 
-    loadTeamInfo()
-  }, [])
   return (
     <footer className="bg-legion-gray-900 text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -3,27 +3,29 @@
 import { useState, useEffect } from 'react'
 import { Menu, X } from 'lucide-react'
 import Image from 'next/image'
+import { useData } from '../hooks/useData'
 
 interface BrandingData {
   logo: {
-    src: string;
-    alt: string;
-    width: number;
-    height: number;
-  };
+    src: string
+    alt: string
+    width: number
+    height: number
+  }
 }
 
 export default function Navbar() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [brandingData, setBrandingData] = useState<BrandingData>({
+  const defaultBranding: BrandingData = {
     logo: {
-      src: "/images/shelley-legion-logo.png",
-      alt: "Shelley Legion Baseball Logo",
+      src: '/images/shelley-legion-logo.png',
+      alt: 'Shelley Legion Baseball Logo',
       width: 60,
       height: 60
     }
-  })
+  }
+  const { data: brandingData } = useData<BrandingData>('branding.json', defaultBranding)
 
   useEffect(() => {
     const handleScroll = () => {
@@ -31,22 +33,6 @@ export default function Navbar() {
     }
     window.addEventListener('scroll', handleScroll)
     return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
-
-  useEffect(() => {
-    const loadBranding = async () => {
-      try {
-        const response = await fetch('/api/data/branding.json')
-        if (response.ok) {
-          const data = await response.json()
-          setBrandingData(data)
-        }
-      } catch (error) {
-        // Keep default data
-      }
-    }
-
-    loadBranding()
   }, [])
 
   const navItems = [
@@ -58,8 +44,7 @@ export default function Navbar() {
   ]
 
   return (
-    <nav className={`fixed w-full z-50 transition-all duration-300 ${isScrolled ? 'bg-black/95 backdrop-blur-md shadow-lg' : 'bg-transparent'
-      }`}>
+    <nav className={`fixed w-full z-50 transition-all duration-300 ${isScrolled ? 'bg-black/95 backdrop-blur-md shadow-lg' : 'bg-transparent'}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-3">

--- a/app/components/ScheduleSection.tsx
+++ b/app/components/ScheduleSection.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { Calendar, MapPin, Clock, Plus } from 'lucide-react'
-import React, { useState, useEffect } from 'react'
 import BaseballBackground from './BaseballBackground'
 import { getEventStatus, formatEventStatus } from '../utils/dateUtils'
+import { useData } from '../hooks/useData'
 
 interface Event {
   date: string
@@ -15,29 +15,13 @@ interface Event {
   description: string
 }
 
+interface ScheduleData {
+  events: Event[]
+}
+
 export default function ScheduleSection() {
-  const [events, setEvents] = useState<Event[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const loadSchedule = async () => {
-      try {
-        const response = await fetch('/api/data/schedule.json')
-        if (response.ok) {
-          const scheduleData = await response.json()
-          setEvents((scheduleData.events || []) as Event[])
-        } else {
-          setEvents([])
-        }
-      } catch (error) {
-        setEvents([])
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    loadSchedule()
-  }, [])
+  const { data, isLoading } = useData<ScheduleData>('schedule.json', { events: [] })
+  const events = data.events
 
   const getEventIcon = (type: string) => {
     switch (type) {
@@ -67,14 +51,14 @@ export default function ScheduleSection() {
 
   const addToCalendar = (event: any) => {
     const startDate = new Date(`${event.date} 2025 ${event.time}`)
-    const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000) // 2 hours later
-    
+    const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000)
+
     const formatDate = (date: Date) => {
       return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
     }
 
     const calendarUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${formatDate(startDate)}/${formatDate(endDate)}&details=${encodeURIComponent(event.description)}&location=${encodeURIComponent(event.location)}`
-    
+
     window.open(calendarUrl, '_blank')
   }
 
@@ -100,57 +84,57 @@ export default function ScheduleSection() {
         ) : (
           <div className="max-w-4xl mx-auto space-y-4">
             {events.map((event, index) => {
-            const currentStatus = getEventStatus(event.date, event.status)
-            const statusDisplay = formatEventStatus(currentStatus)
-            
-            return (
-              <div
-                key={index}
-                className="bg-gradient-to-r from-legion-red-50 to-white dark:from-legion-gray-800 dark:to-legion-gray-700 rounded-xl shadow-md p-6 card-hover border-l-4 border-legion-red-600"
-              >
-                <div className="flex flex-col md:flex-row md:items-center md:justify-between">
-                  <div className="flex items-center space-x-6 mb-4 md:mb-0">
-                    <div className={`${getEventColor(event.type)} text-white rounded-lg p-3 text-center min-w-[80px] flex flex-col items-center`}>
-                      <span className="text-2xl mb-1">{getEventIcon(event.type)}</span>
-                      <div className="font-bold text-xs">{event.date}</div>
-                    </div>
-                    <div>
-                      <div className="flex items-center space-x-3 mb-1">
-                        <h3 className="text-xl font-bold text-legion-gray-900 dark:text-white">
-                          {event.title}
-                        </h3>
-                        <span className={`text-sm font-semibold px-2 py-1 rounded-full ${statusDisplay.color} bg-opacity-10`}>
-                          {statusDisplay.text}
-                        </span>
+              const currentStatus = getEventStatus(event.date, event.status)
+              const statusDisplay = formatEventStatus(currentStatus)
+
+              return (
+                <div
+                  key={index}
+                  className="bg-gradient-to-r from-legion-red-50 to-white dark:from-legion-gray-800 dark:to-legion-gray-700 rounded-xl shadow-md p-6 card-hover border-l-4 border-legion-red-600"
+                >
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+                    <div className="flex items-center space-x-6 mb-4 md:mb-0">
+                      <div className={`${getEventColor(event.type)} text-white rounded-lg p-3 text-center min-w-[80px] flex flex-col items-center`}>
+                        <span className="text-2xl mb-1">{getEventIcon(event.type)}</span>
+                        <div className="font-bold text-xs">{event.date}</div>
                       </div>
-                      <div className="flex items-center space-x-4 text-legion-gray-600 dark:text-legion-gray-300 mb-2">
-                        <div className="flex items-center">
-                          <MapPin className="w-4 h-4 mr-1" />
-                          <span className="font-medium">{event.location}</span>
+                      <div>
+                        <div className="flex items-center space-x-3 mb-1">
+                          <h3 className="text-xl font-bold text-legion-gray-900 dark:text-white">
+                            {event.title}
+                          </h3>
+                          <span className={`text-sm font-semibold px-2 py-1 rounded-full ${statusDisplay.color} bg-opacity-10`}>
+                            {statusDisplay.text}
+                          </span>
                         </div>
-                        <div className="flex items-center">
-                          <Clock className="w-4 h-4 mr-1" />
-                          <span>{event.time}</span>
+                        <div className="flex items-center space-x-4 text-legion-gray-600 dark:text-legion-gray-300 mb-2">
+                          <div className="flex items-center">
+                            <MapPin className="w-4 h-4 mr-1" />
+                            <span className="font-medium">{event.location}</span>
+                          </div>
+                          <div className="flex items-center">
+                            <Clock className="w-4 h-4 mr-1" />
+                            <span>{event.time}</span>
+                          </div>
                         </div>
+                        <p className="text-sm text-legion-gray-600 dark:text-legion-gray-300">
+                          {event.description}
+                        </p>
                       </div>
-                      <p className="text-sm text-legion-gray-600 dark:text-legion-gray-300">
-                        {event.description}
-                      </p>
                     </div>
-                  </div>
-                  <div className="flex space-x-3">
-                    {currentStatus !== 'completed' && currentStatus !== 'cancelled' && (
-                      <button
-                        onClick={() => addToCalendar(event)}
-                        className="bg-legion-red-600 hover:bg-legion-red-700 text-white px-4 py-2 rounded-lg font-semibold transition-colors duration-200 flex items-center space-x-2"
-                      >
-                        <Plus className="w-4 h-4" />
-                        <span>Add to Calendar</span>
-                      </button>
-                    )}
+                    <div className="flex space-x-3">
+                      {currentStatus !== 'completed' && currentStatus !== 'cancelled' && (
+                        <button
+                          onClick={() => addToCalendar(event)}
+                          className="bg-legion-red-600 hover:bg-legion-red-700 text-white px-4 py-2 rounded-lg font-semibold transition-colors duration-200 flex items-center space-x-2"
+                        >
+                          <Plus className="w-4 h-4" />
+                          <span>Add to Calendar</span>
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
               )
             })}
           </div>

--- a/app/components/StatsSection.tsx
+++ b/app/components/StatsSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Trophy, Target, TrendingUp, Award } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useData } from '../hooks/useData'
 
 const iconMap = {
   trophy: Trophy,
@@ -17,29 +17,14 @@ interface TeamStat {
   icon: string
 }
 
+interface StatsData {
+  teamStats: TeamStat[]
+}
+
 export default function StatsSection() {
-  const [teamStats, setTeamStats] = useState<TeamStat[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const { data, isLoading } = useData<StatsData>('stats.json', { teamStats: [] })
+  const teamStats = data.teamStats
 
-  useEffect(() => {
-    const loadStats = async () => {
-      try {
-        const response = await fetch('/api/data/stats.json')
-        if (response.ok) {
-          const statsData = await response.json()
-          setTeamStats((statsData.teamStats || []) as TeamStat[])
-        } else {
-          setTeamStats([])
-        }
-      } catch (error) {
-        setTeamStats([])
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    loadStats()
-  }, [])
   return (
     <section id="stats" className="section-padding bg-black">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -58,20 +43,20 @@ export default function StatsSection() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
             {teamStats.map((stat, index) => {
-            const IconComponent = iconMap[stat.icon as keyof typeof iconMap]
-            return (
-              <div
-                key={index}
-                className="text-center p-6 rounded-xl bg-white/10 backdrop-blur-sm card-hover"
-              >
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-white rounded-full mb-4">
-                  <IconComponent className="w-8 h-8 text-legion-red-600" />
+              const IconComponent = iconMap[stat.icon as keyof typeof iconMap]
+              return (
+                <div
+                  key={index}
+                  className="text-center p-6 rounded-xl bg-white/10 backdrop-blur-sm card-hover"
+                >
+                  <div className="inline-flex items-center justify-center w-16 h-16 bg-white rounded-full mb-4">
+                    <IconComponent className="w-8 h-8 text-legion-red-600" />
+                  </div>
+                  <div className="text-4xl font-bold text-white mb-2">{stat.value}</div>
+                  <div className="text-lg font-semibold text-legion-red-400 mb-1">{stat.label}</div>
+                  <div className="text-legion-gray-300 text-sm">{stat.description}</div>
                 </div>
-                <div className="text-4xl font-bold text-white mb-2">{stat.value}</div>
-                <div className="text-lg font-semibold text-legion-red-400 mb-1">{stat.label}</div>
-                <div className="text-legion-gray-300 text-sm">{stat.description}</div>
-              </div>
-            )
+              )
             })}
           </div>
         )}

--- a/app/components/TeamSection.tsx
+++ b/app/components/TeamSection.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Users } from 'lucide-react'
-import { useState, useEffect } from 'react'
 import BaseballBackground from './BaseballBackground'
+import { useData } from '../hooks/useData'
 
 interface Player {
   number: number
@@ -11,34 +11,13 @@ interface Player {
   stats: string
 }
 
+interface RosterData {
+  players: Player[]
+}
+
 export default function TeamSection() {
-  const [players, setPlayers] = useState<Player[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-
-  const loadRoster = async () => {
-    try {
-      const response = await fetch(`/api/data/roster.json?t=${Date.now()}`, {
-        cache: 'no-store'
-      })
-
-      if (response.ok) {
-        const rosterData = await response.json()
-        setPlayers((rosterData.players || []) as Player[])
-      } else {
-        setPlayers([])
-      }
-    } catch (error) {
-      setPlayers([])
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    loadRoster()
-  }, [])
-
-
+  const { data, isLoading, error } = useData<RosterData>('roster.json', { players: [] })
+  const players = data.players
 
   return (
     <section id="team" className="section-padding bg-legion-gray-50 dark:bg-legion-gray-900 relative overflow-hidden">
@@ -52,7 +31,6 @@ export default function TeamSection() {
           <p className="text-xl text-legion-gray-600 dark:text-legion-gray-300 max-w-2xl mx-auto">
             Our talented young athletes ready to dominate the diamond
           </p>
-
         </div>
 
         {isLoading ? (
@@ -60,7 +38,7 @@ export default function TeamSection() {
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-legion-red-600 mx-auto"></div>
             <p className="mt-4 text-legion-gray-600 dark:text-legion-gray-300">Loading team roster...</p>
           </div>
-        ) : (
+        ) : players.length ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {players.map((player) => (
               <div
@@ -86,6 +64,12 @@ export default function TeamSection() {
                 </div>
               </div>
             ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-legion-gray-600 dark:text-legion-gray-300">
+              {error ? 'Failed to load team roster.' : 'No players found.'}
+            </p>
           </div>
         )}
       </div>

--- a/app/hooks/useData.ts
+++ b/app/hooks/useData.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useData<T>(filename: string, initialData: T) {
+  const [data, setData] = useState<T>(initialData)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    async function load() {
+      setIsLoading(true)
+      try {
+        const res = await fetch(`/api/data/${filename}`, { cache: 'no-store' })
+        if (!res.ok) throw new Error(`Failed to load ${filename}`)
+        const json = await res.json()
+        if (active) {
+          setData(json)
+        }
+      } catch (err) {
+        if (active) {
+          setError(err as Error)
+          setData(initialData)
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    load()
+    return () => {
+      active = false
+    }
+  }, [filename, initialData])
+
+  return { data, isLoading, error }
+}

--- a/app/hooks/useData.ts
+++ b/app/hooks/useData.ts
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export function useData<T>(filename: string, initialData: T) {
-  const [data, setData] = useState<T>(initialData)
+  const initialRef = useRef(initialData)
+  const [data, setData] = useState<T>(initialRef.current)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
 
@@ -22,7 +23,7 @@ export function useData<T>(filename: string, initialData: T) {
       } catch (err) {
         if (active) {
           setError(err as Error)
-          setData(initialData)
+          setData(initialRef.current)
         }
       } finally {
         if (active) {
@@ -35,7 +36,7 @@ export function useData<T>(filename: string, initialData: T) {
     return () => {
       active = false
     }
-  }, [filename, initialData])
+  }, [filename])
 
   return { data, isLoading, error }
 }


### PR DESCRIPTION
## Summary
- add generic `useData` hook for loading JSON from `/api/data`
- switch Team, Stats, Schedule, Navbar and Footer components to `useData` and improve fallback UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e5ef2908322ae8616883e96c19a